### PR TITLE
adding server release workflow

### DIFF
--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -47,4 +47,4 @@ jobs:
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - run: |
           docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/lading:${{ github.sha }} -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/lading:latest
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/lading:${{ github.sha }}
+          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/lading

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -46,6 +46,5 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - run: |
-          docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/lading:${{ github.sha }}
+          docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/lading:${{ github.sha }} -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/lading:latest
           docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/lading:${{ github.sha }}
-

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -30,6 +30,8 @@ jobs:
 
       - run: yarn
 
+      - run: yarn workspace @lading/server build
+
       - run: yarn workspace @lading/server test
 
       - name: 'Login via Azure CLI'

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -1,0 +1,49 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Release Server
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/server/**"
+      - ".github/workflows/release-server.yml"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - run: yarn
+
+      - run: yarn workspace @lading/server test
+
+      - name: 'Login via Azure CLI'
+          uses: azure/login@v1
+          with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+      
+      - name: 'Build and push image'
+        uses: azure/docker-login@v1
+        with:
+          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - run: |
+          docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/lading:${{ github.sha }}
+          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/lading:${{ github.sha }}
+


### PR DESCRIPTION
Much of the info came from here: 

https://docs.microsoft.com/en-us/azure/container-instances/container-instances-github-action

I didn't think we need to muck with the ACI stuff, so I didn't put that in. adds yarn build / test before the docker build