### PR TITLE
Update package.json to include the repository

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -7,6 +7,11 @@
   "scripts": {
     "build": "tsc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/lading.git",
+    "directory":"packages/client"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cloudpack/package.json
+++ b/packages/cloudpack/package.json
@@ -6,6 +6,11 @@
   "scripts": {
     "start": "node src/server.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/lading.git",
+    "directory":"packages/cloudpack"
+  },
   "dependencies": {
     "camelcase": "^6.2.0",
     "express": "^4.17.1"

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -7,6 +7,11 @@
   "scripts": {
     "start": "webpack serve"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/lading.git",
+    "directory":"packages/example"
+  },
   "dependencies": {
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -18,6 +18,11 @@
     "test:lint:fix": "eslint src --ext .ts --fix",
     "typeorm": "tsed typeorm"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/lading.git",
+    "directory":"packages/server"
+  },
   "dependencies": {
     "@tsed/ajv": "^6.21.0",
     "@tsed/common": "^6.21.0",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -6,6 +6,11 @@
   "devDependencies": {
     "webpack": "^5.16.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/lading.git",
+    "directory":"packages/webpack"
+  },
   "peerDependencies": {
     "webpack": "^5.0.0"
   },


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@v-rr](https://github.com/v-rr), [@v-jiepeng](https://github.com/v-jiepeng), [@v-zhzhou](https://github.com/v-zhzhou) and [@v-gjy](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* @lading/client
* @lading/cloudpack
* @lading/example
* @lading/server
* @lading/webpack